### PR TITLE
Update graph.gnuplot to match SVG options (gnuplot 5.2)

### DIFF
--- a/reporter/graph.gnuplot
+++ b/reporter/graph.gnuplot
@@ -1,4 +1,4 @@
-set terminal svg size 600,500 fname "Helvetica" fsize 14
+set terminal svg size 600,500 font "Helvetica,14"
 
 set output "_report/map.svg"
 source="_report/results.txt"


### PR DESCRIPTION
This updates `graph.gnuplot` to match SVG terminal options of `gnuplot` 5.2. For reference see

http://www.bersch.net/gnuplot-doc/complete-list-of-terminals.html#commands-set-terminal-svg

(Isn't it surprising, that there is such a difference between `SVG` and `SVGA` - they differ just by a single letter! :-) )

Please feel free to close the PR if it does not work on your system.